### PR TITLE
Use existing `QApplication`

### DIFF
--- a/runviewer/__main__.py
+++ b/runviewer/__main__.py
@@ -1689,7 +1689,9 @@ class RunviewerServer(ZMQServer):
 
 
 if __name__ == "__main__":
-    qapplication = QApplication(sys.argv)
+    qapplication = QApplication.instance()
+    if qapplication is None:
+        qapplication = QApplication(sys.argv)
 
     shots_to_process_queue = Queue()
 


### PR DESCRIPTION
Instead of creating a new one unconditionally. The splash screen already
creates a `QApplication`, so we had two existing in the interpreter.
Having multiple `QApplication`s in the same thread (possibly in the same
process?) is not allowed and leads to segfaults on `PyQt5` and Python
exceptions on `PySide2`.

Initially reported in labscript-suite/runmanager#74