### PR TITLE
Use `desktop-app` package for desktop integration

### DIFF
--- a/runviewer/desktop-app.json
+++ b/runviewer/desktop-app.json
@@ -1,0 +1,4 @@
+{
+    "product_name": "Labscript Suite",
+    "modules": {"runviewer": {"display_name": "runviewer - the labscript suite"}}
+}

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ INSTALL_REQUIRES = [
     "numpy >=1.15",
     "scipy",
     "h5py",
+    "desktop-app"
 ]
 
 setup(
@@ -68,6 +69,10 @@ setup(
     url='http://labscriptsuite.org',
     license="BSD",
     packages=["runviewer"],
+    entry_points={
+        'console_scripts': ['runviewer = desktop_app:entry_point'],
+        'gui_scripts': ["runviewer-gui = desktop_app:entry_point"],
+    },
     zip_safe=False,
     setup_requires=['setuptools', 'setuptools_scm'],
     include_package_data=True,


### PR DESCRIPTION
Instead of `labscript_utils.winshell` and `labscript_utils.winlauncher`.

OS menu (e.g. Start menu on Windows) shortcuts can be created with
`desktop-app install runviewer`

And runviewer can be run from the terminal with `runviewer` or
`runviewer-gui` to run without a console on Windows.

Interestingly, runviewer already had the line (removed in this patch)

```python
ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
```

in addition to the per-window appusermodel_id calls, but not with the same appid.