### PR TITLE
Require pre-release pyqtgraph on Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ except ImportError:
 INSTALL_REQUIRES = [
     "labscript_devices",
     "labscript_utils >=2.15",
-    "pyqtgraph >=0.9.10",
+    "pyqtgraph >=0.11.0rc0;         python_version >= '3.8'",
+    "pyqtgraph >=0.9.10;            python_version < '3.8'",
     "qtutils >=2.0.0",
     "zprocess",
     "numpy >=1.15",


### PR DESCRIPTION
I thought depending on labscript_utils which depends on the newer
pyqtgraph would be sufficient, but it's not - if runviewer is processed
by pip first, pip does not install the pre-release version even though
labscript_utils requires is. Maybe a bug in pip, or known deficiency in
its dependency resolution, but this fixes it.