### PR TITLE
Automated build and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Unshallow
+        if: github.event.ref_type != 'tag'
         run: |
           git fetch --prune --unshallow
           git describe --tags
@@ -47,7 +48,7 @@ jobs:
           SCM_LOCAL_SCHEME: no-local-version
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install -U git+https://github.com/chrisjbillington/setuptools_scm.git@release-branch-semver-scheme
+          pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5fd42cb257c86e6dbe720eaee6d1e2c9b
           python setup.py sdist bdist_wheel
           SCM_VERSION=$(python setup.py --version)
           echo "::set-env name=SCM_VERSION::$SCM_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           python-version: 3.8
       - name: Build Distribution
         env:
+          SCM_VERSION_SCHEME: release-branch-semver
           SCM_LOCAL_SCHEME: no-local-version
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Build and release
+on:
+  push:
+    branches:
+      - master
+      - maintenance/*
+  create:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  github_properties:
+    name: GitHub Properties
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enumerate properties
+        run: |
+          echo github.ref: ${{ github.ref }}
+          echo github.event_name: ${{ github.event_name }}
+          echo github.event: ${{ github.event }}
+          echo github.event.name: ${{ github.event.name }}
+          echo github.event.ref: ${{ github.event.ref }}
+          echo github.event.ref_type: ${{ github.event.ref_type }}
+          echo github.event.master_branch: ${{ github.event.master_branch }}
+          echo github.actor: ${{ github.actor }}
+  release:
+    name: Build and release
+    runs-on: ubuntu-latest
+    needs: github_properties
+    env:
+      PACKAGE_NAME: runviewer
+    if: github.repository == 'labscript-suite/runviewer' && (github.event_name != 'create' || github.event.ref_type != 'branch')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+          git describe --tags
+          git log -1
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Build Distribution
+        env:
+          SCM_LOCAL_SCHEME: no-local-version
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -U git+https://github.com/chrisjbillington/setuptools_scm.git@release-branch-semver-scheme
+          python setup.py sdist bdist_wheel
+          SCM_VERSION=$(python setup.py --version)
+          echo "::set-env name=SCM_VERSION::$SCM_VERSION"
+      - name: Publish on TestPyPI
+        if: github.event.ref_type == 'tag' || contains(env.SCM_VERSION, 'dev')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.testpypi }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Get Version Number
+        if: github.event.ref_type == 'tag'
+        run: |
+          VERSION="${GITHUB_REF/refs\/tags\/v/}"
+          echo "::set-env name=VERSION::$VERSION"
+      - name: Create GitHub Release
+        if: github.event.ref_type == 'tag'
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.ref }}
+          release_name: ${{ env.PACKAGE_NAME }} ${{ env.VERSION }}
+          draft: true
+          prerelease: ${{ contains(github.event.ref, 'rc') }}
+      - name: Upload Release Asset
+        if: github.event.ref_type == 'tag'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist/${{ env.PACKAGE_NAME }}-${{ env.VERSION }}.tar.gz
+          asset_name: ${{ env.PACKAGE_NAME }}-${{ env.VERSION }}.tar.gz
+          asset_content_type: application/gzip
+      - name: Publish on PyPI
+        if: github.event.ref_type == 'tag'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,27 +8,18 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  github_properties:
-    name: GitHub Properties
+  build:
+    name: Build and Release
     runs-on: ubuntu-latest
-    steps:
-      - name: Enumerate properties
-        run: |
-          echo github.ref: ${{ github.ref }}
-          echo github.event_name: ${{ github.event_name }}
-          echo github.event: ${{ github.event }}
-          echo github.event.name: ${{ github.event.name }}
-          echo github.event.ref: ${{ github.event.ref }}
-          echo github.event.ref_type: ${{ github.event.ref_type }}
-          echo github.event.master_branch: ${{ github.event.master_branch }}
-          echo github.actor: ${{ github.actor }}
-  release:
-    name: Build and release
-    runs-on: ubuntu-latest
-    needs: github_properties
     env:
       PACKAGE_NAME: runviewer
+      SCM_VERSION_SCHEME: release-branch-semver
+      SCM_LOCAL_SCHEME: no-local-version
     if: github.repository == 'labscript-suite/runviewer' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:
       - name: Checkout
@@ -37,16 +28,12 @@ jobs:
         if: github.event.ref_type != 'tag'
         run: |
           git fetch --prune --unshallow
-          git describe --tags
-          git log -1
+          git tag -d $(git tag --points-at HEAD)
       - name: Install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Build Distribution
-        env:
-          SCM_VERSION_SCHEME: release-branch-semver
-          SCM_LOCAL_SCHEME: no-local-version
+      - name: Build Distributions
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5fd42cb257c86e6dbe720eaee6d1e2c9b

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,5 +50,3 @@ pyqt = PyQt5
 
 [dist_conda]
 pythons = 3.6, 3.7, 3.8
-platforms = linux-64,win-32,win-64,osx-64
-force_conversion = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 from setuptools import setup
-from setuptools.dist import Distribution
 
 try:
     from setuptools_conda import dist_conda

--- a/setup.py
+++ b/setup.py
@@ -8,28 +8,12 @@ try:
 except ImportError:
     CMDCLASS = {}
 
-if "CONDA_BUILD" not in os.environ:
-    dist = Distribution()
-    dist.parse_config_files()
-    INSTALL_REQUIRES = dist.command_options["options"]["install_requires"][1]
-    INSTALL_REQUIRES = INSTALL_REQUIRES.strip().split('\n')
-else:
-    INSTALL_REQUIRES = []
-
-VERSION_SCHEME = {}
-VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "guess-next-dev"
-)
-VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
-
-VERSION_SCHEME = {}
-VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "release-branch-semver"
-)
-VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
 
 setup(
     use_scm_version=VERSION_SCHEME,
     cmdclass=CMDCLASS,
-    install_requires=INSTALL_REQUIRES
 )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,12 @@ VERSION_SCHEME["version_scheme"] = os.environ.get(
 )
 VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
 
+VERSION_SCHEME = {}
+VERSION_SCHEME["version_scheme"] = os.environ.get(
+    "SCM_VERSION_SCHEME", "release-branch-semver"
+)
+VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
+
 setup(
     use_scm_version=VERSION_SCHEME,
     cmdclass=CMDCLASS,


### PR DESCRIPTION
Automate source and built distributions per [rpanderson/workflow-sandbox 0.3.0](https://github.com/rpanderson/workflow-sandbox/releases).

* All tagged releases (including candidates) are published on PyPI and TestPyPI automatically.
* All untagged pushes to `master` and `maintenance/*` branches are published on TestPyPI automatically with a `dev` version.
* Using the `release-branch-semver` version scheme of pypa/setuptools_scm#430.
