### PR TITLE
Restore use of desktop-app (#30) with setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,10 +25,11 @@ include_package_data = True
 packages = find:
 python_requires = >=3.6
 install_requires =
-  desktop-app>=0.1.1.dev5
+  desktop-app>=0.1.2
   labscript_devices
   labscript_utils>=2.15
-  pyqtgraph>=0.9.10
+  pyqtgraph>=0.11.0rc0 ; python_version>='3.8'
+  pyqtgraph>=0.9.10 ; python_version<'3.8'
   qtutils>=2.0.0
   zprocess
   numpy>=1.15

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.6
 install_requires =
+  desktop-app>=0.1.1.dev5
   labscript_devices
   labscript_utils>=2.15
   pyqtgraph>=0.9.10
@@ -35,6 +36,12 @@ install_requires =
   h5py
 setup_requires =
   setuptools_scm
+
+[options.entry_points]
+console_scripts =
+  runviewer = desktop_app:entry_point
+gui_scripts = 
+  runviewer-gui = desktop_app:entry_point
 
 [options.extras_require]
 pyqt = PyQt5


### PR DESCRIPTION
#30 got discarded in #32. Restoring the use of `desktop-app` but with setup.cfg. Adding version requirement for `desktop-app>=0.1.1.dev5` which partially resolves chrisjbillington/desktop-app#1. Defer merging this until 0.1.1.dev6 or greater is on PyPI, which fully resolves chrisjbillington/desktop-app#1.