### PR TITLE
Depend unconditionally on importlib_metadata and new pyqtgraph.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,10 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   desktop-app>=0.1.2
-  importlib_metadata ; python_version<'3.8'
+  importlib_metadata
   labscript_devices
   labscript_utils>=2.15
-  pyqtgraph>=0.11.0rc0 ; python_version>='3.8'
-  pyqtgraph>=0.9.10 ; python_version<'3.8'
+  pyqtgraph>=0.11.0rc0
   qtutils>=2.0.0
   zprocess
   numpy>=1.15


### PR DESCRIPTION
This is so that we can make a pure conda package. Whilst the new
pyqtgraph isn't in the conda repos (and isn't released yet), we can
supply it from the labscript-suite channel until it is in the main
channel.