### PR TITLE
Updated runviewer to use the new labscript-utils device registry.

### DIFF
--- a/runviewer/__main__.py
+++ b/runviewer/__main__.py
@@ -63,7 +63,7 @@ from qtutils import *
 import qtutils.icons
 splash.update_text('importing labscript suite modules')
 from labscript_utils.connections import ConnectionTable
-import labscript_devices
+from labscript_utils import device_registry
 
 from labscript_utils.labconfig import LabConfig, save_appconfig, load_appconfig
 from labscript_utils.ls_zprocess import ZMQServer, ProcessTree
@@ -1521,8 +1521,7 @@ class Shot(object):
             print('loading %s' % device.name)
             module = device.device_class
             # Load the master pseudoclock class
-            # labscript_devices.import_device(module)
-            device_class = labscript_devices.get_runviewer_parser(module)
+            device_class = device_registry.get_runviewer_parser(module)
             device_instance = device_class(self.path, device)
             clocklines_and_triggers = device_instance.get_traces(self.add_trace, clock)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,7 @@ python_requires = >=3.6
 install_requires =
   desktop-app>=0.1.2
   importlib_metadata
-  labscript_devices>=3.0.0
-  labscript_utils>=3.0.0
+  labscript_utils>=3.1.0b1
   labscript-c-extensions
   pyqtgraph>=0.11.0rc0
   qtutils>=2.0.0


### PR DESCRIPTION

Removes the circular dependency on labscript-devices.

This update assumes we will publish a new labscript-utils beta (3.1.0b1) shortly (so will fail to build on RTD until that is done)