### PR TITLE
Fix RTD build

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -23,5 +23,4 @@ python:
         path: .
         extra_requirements:
             - docs
-   system_packages: true
    


### PR DESCRIPTION
Remove deprecated `system_packages` option.