### PR TITLE
Remove shot from "select markers" drop down when shot is removed

### DIFF
--- a/runviewer/__main__.py
+++ b/runviewer/__main__.py
@@ -696,6 +696,9 @@ class RunViewer(object):
             # unselect shot
             item.setCheckState(Qt.Unchecked)
             shutter_item.setCheckState(Qt.Unchecked)
+            # remove shot from markers list
+            shot_combobox_index = self.ui.markers_comboBox.findText(os.path.basename(shot.path))
+            self.ui.markers_comboBox.removeItem(shot_combobox_index)
             # remove row
             self.shot_model.removeRow(row)
             del shot


### PR DESCRIPTION
The pull request attempts to resolve issue #44 by removing shots from the "select markers" drop down when the shot is removed from runviewer.
It successfully avoids issues with shots being loaded, deleted, and loaded again.
However, this PR does change the behavior of runviewer in that previously loaded shots are no longer visible (greyed out) in the "select markers" drop down. In my opinion, the new behavior is acceptable, and---since the entries for deleted shots are greyed out---it should not impact workflows.
The case of loading the same shot twice, the removing one or both also seems to be handled correctly.