### PR TITLE
Add Pyqt6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "labscript_utils>=3.1.0b1",
     "labscript-c-extensions",
     "pyqtgraph>=0.11.1",
-    "qtutils>=4.0.0",
+    "qtutils>=4.1.1",
     "zprocess",
     "numpy>=1.15",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "labscript_utils>=3.1.0b1",
     "labscript-c-extensions",
     "pyqtgraph>=0.11.1",
-    "qtutils>=4.1.1",
+    "qtutils>=4.1.3",
     "zprocess",
     "numpy>=1.15",
     "scipy",

--- a/runviewer/__main__.py
+++ b/runviewer/__main__.py
@@ -1671,7 +1671,6 @@ class RunviewerServer(ZMQServer):
 if __name__ == "__main__":
     qapplication = QtWidgets.QApplication.instance()
     if qapplication is None:
-        qapplication = QApplication(sys.argv)
         qapplication = QtWidgets.QApplication(sys.argv)
 
     shots_to_process_queue = Queue()

--- a/runviewer/__main__.py
+++ b/runviewer/__main__.py
@@ -197,7 +197,10 @@ class RunviewerMainWindow(QtWidgets.QMainWindow):
     def changeEvent(self, event):
         
         # theme update only for PySide6/PyQt6
-        if QT_ENV.endswith('6') and event.type() == QtCore.QEvent.Type.ThemeChange:
+        if (QT_ENV.endswith('6')
+            and (event.type() == QtCore.QEvent.Type.ApplicationPaletteChange
+            or event.type() == QtCore.QEvent.Type.StyleChange)):
+
             for widget in self.findChildren(QtWidgets.QWidget):
                 # Complex widgets, like TreeView and TableView require triggering styleSheet and palette updates
                 widget.setStyleSheet(widget.styleSheet())


### PR DESCRIPTION
Fully qualifies all enums and fixes the theme switching to be compatible between PySide6 and PyQt6

Note: Icons are not loading under PyQt6. Suspect an issue with qtutils.

Edit: With qtutils 4.1.1, fully qualified enums no longer needed. Not going to bother doing them in favor of focusing support on PySide6 long term